### PR TITLE
Quiet Hours Refactor + Web UI Improvements

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -7,19 +7,19 @@ fi
 
 # Determine virtualenv path
 if [ "$ENVIRONMENT" == "development" ]; then
-    VENV_PATH="venv"
+    VENV_PATH="./venv"
 else
     VENV_PATH="$HOME/.virtualenvs/movieframe"
 fi
 
-if [ ! -d "$VENV_DIR" ]; then
-  echo "❌ Virtual environment not found at $VENV_DIR"
+if [ ! -d "$VENV_PATH" ]; then
+  echo "❌ Virtual environment not found at $VENV_PATH"
   echo "💡 Run './project-install.sh' to set it up first."
   exit 1
 fi
 
 echo "✅ Activating virtual environment..."
-source "$VENV_DIR/bin/activate"
+source "$VENV_PATH/bin/activate"
 
 echo "🚀 Launching movieplayer..."
 python movieplayer.py

--- a/launch.sh
+++ b/launch.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-VENV_DIR="$HOME/.virtualenvs/movieframe"
+# Load ENVIRONMENT from .env if present
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | xargs)
+fi
+
+# Determine virtualenv path
+if [ "$ENVIRONMENT" == "development" ]; then
+    VENV_PATH="venv"
+else
+    VENV_PATH="$HOME/.virtualenvs/movieframe"
+fi
 
 if [ ! -d "$VENV_DIR" ]; then
   echo "❌ Virtual environment not found at $VENV_DIR"

--- a/project-install.sh
+++ b/project-install.sh
@@ -2,7 +2,18 @@
 
 set -e  # Exit on first error
 
-VENV_PATH="$HOME/.virtualenvs/movieframe"
+
+# Load ENVIRONMENT from .env if present
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | xargs)
+fi
+
+# Determine virtualenv path
+if [ "$ENVIRONMENT" == "development" ]; then
+    VENV_PATH="venv"
+else
+    VENV_PATH="$HOME/.virtualenvs/movieframe"
+fi
 
 # Create virtual environment if not exists
 if [ ! -d "$VENV_PATH" ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ lgpio==0.2.2.0
 lxml==5.4.0
 MarkupSafe==3.0.2
 matplotlib==3.10.3
-numpy==2.3.0
+numpy >= 2.0.0
 opencv-python==4.11.0.86
 packaging==25.0
 pandas==2.3.0

--- a/static/CSS/style.css
+++ b/static/CSS/style.css
@@ -7,32 +7,32 @@
 
 body {
     font-family: 'AncizarSans', sans-serif;
-    margin: 30px;
-    padding: 0;
+    margin: 0px;
+    padding: 30px;
     background-color: #333;
     color: #f0f0f0;
 }
 
 
 a:link {
-  color:#008000;
+  color:#b5e550;
   text-decoration: none;
 }
 
 /* visited link */
 a:visited {
-  color:#008000;  
+  color:#b5e550;  
 }
 
 /* mouse over link */
 a:hover {
-  color: #5CE65C;
+  color: #abc32f;
   text-decoration: underline;
 }
 
 /* selected link */
 a:active {
-  color:#008000;
+  color:#ececa3;
 }
 
 button {
@@ -97,6 +97,7 @@ main {
 
 .button-container {
     display: flex;
+    flex-direction: column;
     gap: 20px;
 }
 
@@ -105,8 +106,34 @@ main {
 }
 
 .active_status {
-    background: green; 
-    color: white; 
-    padding: 2px 6px; 
-    border-radius: 4px;
+    display:inline-block;
+    padding-right: 8px;;
+}
+
+.movie-item {
+    padding: 12px 0;
+    display: flex;
+    align-items: center;
+}
+
+.movie-link {
+    display:inline-block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dev-mode-text {
+    color: orange;
+    font-weight: bold;
+}   
+
+body.dev-mode {
+    border: orange 2px solid;
+}
+
+.form-flex {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
 }

--- a/static/CSS/style.css
+++ b/static/CSS/style.css
@@ -56,17 +56,32 @@ button:active {
 
 
 
-nav {
-    background-color: rgba(0,0,0,0.20);
+.navbar {
+    background-color: rgba(0, 0, 0, 0.2);
     padding: 1em;
+    position: relative;
 }
 
-nav a {
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    font-size: 2em;
+    color: white;
+    cursor: pointer;
+}
+
+.nav-links {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.nav-links a {
     margin-right: 1em;
     font-size: 1.2em;
     text-decoration: none;
     font-weight: bold;
-    color: #ffffff;
+    color: orange;
 }
 
 main {
@@ -136,4 +151,36 @@ body.dev-mode {
     display: flex;
     flex-direction: column;
     gap: 20px;
+}
+
+.quiet-hours {
+    margin: 1em 0;
+    padding: 0.5em;
+    border-left: 4px solid #888;
+    background: rgba(0,0,0,0.1);
+}
+
+.quiet-hours.active {
+    background: rgba(255,0,0,0.1);
+}
+
+/* Mobile styles */
+@media (max-width: 768px) {
+    .menu-toggle {
+        display: block;
+    }
+
+    .nav-links {
+        display: none;
+        flex-direction: column;
+        margin-top: 1em;
+    }
+
+    .nav-links.show {
+        display: flex;
+    }
+
+    .nav-links a {
+        margin: 0.5em 0;
+    }
 }

--- a/static/CSS/style.css
+++ b/static/CSS/style.css
@@ -9,27 +9,87 @@ body {
     font-family: 'AncizarSans', sans-serif;
     margin: 30px;
     padding: 0;
+    background-color: #333;
+    color: #f0f0f0;
 }
 
+
+a:link {
+  color:#008000;
+  text-decoration: none;
+}
+
+/* visited link */
+a:visited {
+  color:#008000;  
+}
+
+/* mouse over link */
+a:hover {
+  color: #5CE65C;
+  text-decoration: underline;
+}
+
+/* selected link */
+a:active {
+  color:#008000;
+}
+
+button {
+	background-color:#008000;;
+	border-radius:40px;
+	border:1px solid rgba(0,0,0,0.20);
+	display:inline-block;
+	cursor:pointer;
+	color:#ffffff;
+	font-size:17px;
+	padding:12px 18px;
+	text-decoration:none;
+}
+button:hover {
+	background-color:#5CE65C;
+}
+button:active {
+	position:relative;
+	top:1px;
+}
+
+
+
 nav {
-    background: #f0f0f0;
+    background-color: rgba(0,0,0,0.20);
     padding: 1em;
 }
 
 nav a {
     margin-right: 1em;
+    font-size: 1.2em;
     text-decoration: none;
     font-weight: bold;
-    color: #333;
+    color: #ffffff;
 }
 
 main {
     padding: 1em;
 }
 
+.movie-playback {
+    text-align: center;
+    margin-top: 20px;
+    width: 100%;
+    max-width: 800px;
+    display: block;
+    margin: 0 auto;
+}
+
+.active_frame {
+    width: 100%;
+    height: auto;
+}
+
 #frameProgress {
     color: #669bbc;  /* the progress color */
-    background: lightgrey; /* the background color */
+    background-color: lightgrey; /* the background color */
     height: 20px;
     width: 100%;
     appearance: none;
@@ -42,4 +102,11 @@ main {
 
 .spacer {
     height: 20px; /* Adjust as needed */
+}
+
+.active_status {
+    background: green; 
+    color: white; 
+    padding: 2px 6px; 
+    border-radius: 4px;
 }

--- a/templates/_movie_playback_status.html
+++ b/templates/_movie_playback_status.html
@@ -5,23 +5,23 @@
             <progress id="frameProgress" max="{{ movie['total_frames'] }}" value="{{ movie['current_frame'] }}"></progress>
             <div>frame: {{ movie['current_frame'] }} of {{ movie['total_frames'] }}</div>
         </div>
+
+        <p><strong>Estimated playback time:</strong>
+            {{ playback_time[0] }} years,
+            {{ playback_time[1] }} days,
+            {{ playback_time[2] }} hours,
+            {{ playback_time[3] }} minutes
+        </p>
+
+        {% if movie['isActive'] %}
+            <form action="{{ url_for('stop_playback') }}" method="post">
+                <button type="submit">Stop Playback</button>
+            </form>
+        {% else %}
+            <form action="{{ url_for('start_playback', movie_id=movie['id']) }}" method="post">
+                <button type="submit">Start Playback</button>
+            </form>
+        {% endif %}
     </div>
 
-
-    <p><strong>Estimated playback time:</strong>
-        {{ playback_time[0] }} years,
-        {{ playback_time[1] }} days,
-        {{ playback_time[2] }} hours,
-        {{ playback_time[3] }} minutes
-    </p>
-
-
-    {% if movie['isActive'] %}
-        <form action="{{ url_for('stop_playback') }}" method="post">
-            <button type="submit">Stop Playback</button>
-        </form>
-    {% else %}
-        <form action="{{ url_for('start_playback', movie_id=movie['id']) }}" method="post">
-            <button type="submit">Start Playback</button>
-        </form>
-    {% endif %}
+    

--- a/templates/_movie_playback_status.html
+++ b/templates/_movie_playback_status.html
@@ -1,0 +1,27 @@
+    <div class="movie-playback">
+        <img class="active_frame" src="{{ url_for('static', filename=movie['id'] ~ '/frame.jpg') }}" />
+        <div style="margin-top: 1em;">
+            <label for="frameProgress">Progress:</label>
+            <progress id="frameProgress" max="{{ movie['total_frames'] }}" value="{{ movie['current_frame'] }}"></progress>
+            <div>frame: {{ movie['current_frame'] }} of {{ movie['total_frames'] }}</div>
+        </div>
+    </div>
+
+
+    <p><strong>Estimated playback time:</strong>
+        {{ playback_time[0] }} years,
+        {{ playback_time[1] }} days,
+        {{ playback_time[2] }} hours,
+        {{ playback_time[3] }} minutes
+    </p>
+
+
+    {% if movie['isActive'] %}
+        <form action="{{ url_for('stop_playback') }}" method="post">
+            <button type="submit">Stop Playback</button>
+        </form>
+    {% else %}
+        <form action="{{ url_for('start_playback', movie_id=movie['id']) }}" method="post">
+            <button type="submit">Start Playback</button>
+        </form>
+    {% endif %}

--- a/templates/_quiet_status.html
+++ b/templates/_quiet_status.html
@@ -1,0 +1,14 @@
+{% set now = current_hour or 0 %}
+
+<div style="padding: 0.5rem; border: 1px solid #ccc; margin-bottom: 1rem; background-color: #f8f8f8;">
+    {% if quiet_info.enabled %}
+        <strong>Quiet Hours:</strong> {{ quiet_info.start }}:00 to {{ quiet_info.end }}:00<br>
+        {% if quiet_info.active %}
+            <span style="color: red;">Updates are currently suppressed (within quiet hours).</span>
+        {% else %}
+            <span style="color: green;">Updates are currently allowed (outside quiet hours).</span>
+        {% endif %}
+    {% else %}
+        <span style="color: green;">Quiet hours are disabled.</span>
+    {% endif %}
+</div>

--- a/templates/firstrun.html
+++ b/templates/firstrun.html
@@ -8,7 +8,18 @@
     <title>Available Movies</title>
 </head>
 <body>
-    It looks like this is your first time running this. To get started, please select a video file from the list below:
+   
+</body>
+</html>
+
+{% extends "layout.html" %}
+
+{% block title %}Movie Frame Home{% endblock %}
+{% block content %}
+    <h1>Configure Movie</h1>
+
+
+     It looks like this is your first time setting up this movie file. To get started, please select a video file from the list below:
     <form action="{{ url_for('add_movie') }}" method="post">
         <select name="video_path">
             {% for movie in movies %}
@@ -17,5 +28,5 @@
         </select>
         <input type="submit" value="Select">
     </form>
-</body>
-</html>
+
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,14 +4,31 @@
 {% block content %}
     <h1>Movie Frame Controls</h1>
 
+    {% if quiet_info.enabled %}
+        <div class="quiet-hours {% if quiet_info.active %}active{% endif %}">
+            💤 Quiet Hours are <strong>enabled</strong>
+            ({{ quiet_info.start }}:00 – {{ quiet_info.end }}:00)
+            {% if quiet_info.active %}
+                and <span style="color: red;">active now</span>.
+            {% else %}
+                but <span style="color: green;">not currently active</span>.
+            {% endif %}
+            <a href="{{ url_for('settings_page') }}" style="margin-left: 1em;">Edit Settings</a>
+        </div>
+    {% else %}
+        <!-- <div style="margin: 1em 0; font-size: 0.9em; color: #666;">
+            Quiet Hours are disabled.
+            <a href="{{ url_for('settings_page') }}">Enable in Settings</a>
+        </div> -->
+    {% endif %}
 
     
-        {% if active_movie %}
-            {% set movie = active_movie %}
-            <div id="playback_status"></div>
-                {% include "_movie_playback_status.html" %}
-            </div>
-        {% endif %}
+    {% if active_movie %}
+        {% set movie = active_movie %}
+        <div id="playback_status"></div>
+            {% include "_movie_playback_status.html" %}
+        </div>
+    {% endif %}
     
 
     

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,34 +8,15 @@
         <p style="color: orange;"><strong>Developer Mode:</strong> Frame is not being sent to e-ink display.</p>
     {% endif %}
 
+    
+        {% if active_movie %}
+            {% set movie = active_movie %}
+            <div id="playback_status"></div>
+                {% include "_movie_playback_status.html" %}
+            </div>
+        {% endif %}
+    
 
-    {% if movies %}
-        <ul>
-            {% for movie in movies %}
-                <li>
-                    <a href="{{ url_for('movie', movie_id=movie.id) }}">{{ movie.video_path }}</a>
-                    {% if movie.isActive %}
-                        <span style="background: green; color: white; padding: 2px 6px; border-radius: 4px;">Active</span>
-                    {% endif %}
-                </li>
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p>No movies found. Add one from the <a href="{{ url_for('first_run') }}">first run</a> page.</p>
-    {% endif %}
-
-    <form action="{{ url_for('stop_playback') }}" method="post" style="margin-top: 1em;">
-        <button type="submit">Stop Playback</button>
-    </form>
-
-    <div>
-        <h2>System Info</h2>
-        <ul>
-            <li><strong>Total Disk:</strong> {{ disk_stats.total_gb }} GB</li>
-            <li><strong>Used Disk:</strong> {{ disk_stats.used_gb }} GB</li>
-            <li><strong>Free Disk:</strong> {{ disk_stats.free_gb }} GB</li>
-            <li><strong>Video Directory Size:</strong> {{ video_dir_size }} GB</li>
-        </ul>
-    </div>
+    
 
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,9 @@
         <div id="playback_status"></div>
             {% include "_movie_playback_status.html" %}
         </div>
+    {% else %}
+        <p>No movie is currently playing.</p>
+        <a href="{{ url_for('movies') }}">Select a movie for playback</a>
     {% endif %}
     
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,9 +4,6 @@
 {% block content %}
     <h1>Movie Frame Controls</h1>
 
-    {% if dev_mode %}
-        <p style="color: orange;"><strong>Developer Mode:</strong> Frame is not being sent to e-ink display.</p>
-    {% endif %}
 
     
         {% if active_movie %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,10 +8,14 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='CSS/style.css') }}">
 </head>
 <body {% if dev_mode %}class="dev-mode"{% endif %}>
-    <nav>
-        <a href="{{ url_for('home') }}">Home</a>
-        <a href="{{ url_for('movies') }}">Movies</a>
-        <a href="{{ url_for('upload') }}">Upload Movie</a>
+    <nav class="navbar">
+        <div class="menu-toggle" onclick="toggleMenu()">☰</div>
+        <div class="nav-links" id="navLinks">
+            <a href="{{ url_for('home') }}">Home</a>
+            <a href="{{ url_for('movies') }}">Movies</a>
+            <a href="{{ url_for('upload') }}">Upload Movie</a>
+            <a href="{{ url_for('settings_page') }}">Settings</a>
+        </div>
     </nav>
 
     <main>
@@ -20,5 +24,12 @@
         {% endif %}
         {% block content %}{% endblock %}
     </main>
+
+    <script>
+        function toggleMenu() {
+            const navLinks = document.getElementById('navLinks');
+            navLinks.classList.toggle('show');
+        }
+    </script>
 </body>
 </html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" type="image/x-icon">
     <link rel="stylesheet" href="{{ url_for('static', filename='CSS/style.css') }}">
 </head>
-<body>
+<body {% if dev_mode %}class="dev-mode"{% endif %}>
     <nav>
         <a href="{{ url_for('home') }}">Home</a>
         <a href="{{ url_for('movies') }}">Movies</a>
@@ -15,6 +15,9 @@
     </nav>
 
     <main>
+        {% if dev_mode %}
+            <div class="dev-mode-text"><strong>Developer Mode:</strong> Frame is not being sent to e-ink display.</div>
+        {% endif %}
         {% block content %}{% endblock %}
     </main>
 </body>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -10,6 +10,7 @@
 <body>
     <nav>
         <a href="{{ url_for('home') }}">Home</a>
+        <a href="{{ url_for('movies') }}">Movies</a>
         <a href="{{ url_for('upload') }}">Upload Movie</a>
     </nav>
 

--- a/templates/movie_details.html
+++ b/templates/movie_details.html
@@ -40,22 +40,6 @@
                 <input type="checkbox" name="isRandom" id="isRandom" value="True" {% if movie['isRandom'] %} checked {% endif %}>
             </div>
             <div class="spacer"></div>
-            <div id="enable_quiet_hours">
-                <label>
-                    <input type="checkbox" id="use_quiet_hours" name="use_quiet_hours" value="1" {% if movie.use_quiet_hours %}checked{% endif %}>
-                    Enable Quiet Hours
-                </label>
-            </div>
-
-            <div id="quiet_hours" {% if not movie.use_quiet_hours %}style="display: none;"{% endif %}>
-                <label for="quiet_start">Quiet Hours Start (24h):</label>
-                <input type="number" name="quiet_start" id="quiet_start" min="0" max="23" value="{{ movie.quiet_start or 22 }}">
-
-                <label for="quiet_end">Quiet Hours End (24h):</label>
-                <input type="number" name="quiet_end" id="quiet_end" min="0" max="23" value="{{ movie.quiet_end or 7 }}">
-            </div>
-
-            <div class="spacer"></div>        
             <div class="button-container">
                 <div><button id="submitButton">Submit</button></div>
                 <div><button id="refreshDisplay">Update Display Now</button></div>
@@ -75,11 +59,6 @@
             customTime.style.display = this.value === "0" ? "block" : "none";
         });
 
-        document.getElementById('use_quiet_hours').addEventListener('change', function() {
-            const quietHoursDiv = document.getElementById('quiet_hours');
-            quietHoursDiv.style.display = this.checked ? 'block' : 'none';
-        });
-
         document.getElementById("submitButton").addEventListener("click", function (e) {
             e.preventDefault(); // prevent default form submit
             const form = document.getElementById("movieForm");
@@ -92,7 +71,6 @@
 
             // Normalize checkboxes
             formObject.isRandom = formObject.isRandom ? 1 : 0;
-            formObject.use_quiet_hours = document.getElementById("use_quiet_hours").checked ? 1 : 0;
 
             fetch('/update_movie', {
                 method: 'POST',

--- a/templates/movie_details.html
+++ b/templates/movie_details.html
@@ -59,34 +59,9 @@
 
     <div class="spacer"></div>
 
-    <img src="{{ url_for('static', filename=movie['id'] ~ '/frame.jpg') }}" />
-    <div style="margin-top: 1em;">
-        <label for="frameProgress">Progress:</label>
-        <progress id="frameProgress" max="{{ movie['total_frames'] }}" value="{{ movie['current_frame'] }}"></progress>
-        <div>frame: {{ movie['current_frame'] }} of {{ movie['total_frames'] }}</div>
+    <div id="playback_status">
+        {% include "_movie_playback_status.html" %}
     </div>
-
-
-    <p><strong>Estimated playback time:</strong>
-        {{ playback_time[0] }} years,
-        {{ playback_time[1] }} days,
-        {{ playback_time[2] }} hours,
-        {{ playback_time[3] }} minutes
-    </p>
-
-
-    {% if movie['isActive'] %}
-        <form action="{{ url_for('stop_playback') }}" method="post">
-            <button type="submit">Stop Playback</button>
-        </form>
-    {% else %}
-        <form action="{{ url_for('start_playback', movie_id=movie['id']) }}" method="post">
-            <button type="submit">Start Playback</button>
-        </form>
-    {% endif %}
-
-    
-
 
     <script>
         document.getElementById("time_per_frame").addEventListener("change", function () {
@@ -131,7 +106,7 @@
                 console.error('There was an error!', error);
             });
         });
-        
+
         document.getElementById('refreshDisplay').addEventListener('click', function() {
             fetch(`/trigger_display_update/{{ movie.id }}`, {
                 method: 'POST'

--- a/templates/movie_details.html
+++ b/templates/movie_details.html
@@ -7,54 +7,60 @@
 
     <form id="movieForm">
         <input type="hidden" name="id" value="{{ movie['id'] }}">
+        <div class="form-flex">
+            <div>
+                <label for="time_per_frame">Select update interval:</label>
+                <select name="time_per_frame" id="time_per_frame">
+                    <option value="10" {% if movie['time_per_frame'] == 10 %} selected {% endif %}>Every 10 minutes</option>
+                    <option value="60" {% if movie['time_per_frame'] == 60 %} selected {% endif %}>Every hour</option>
+                    <option value="1440" {% if movie['time_per_frame'] == 1440 %} selected {% endif %}>Every day</option>
+                    <option value="0" {% if movie['time_per_frame'] not in [10, 60, 1440] %} selected {% endif %}>Other (provide custom time in minutes)</option>
+                </select>
+            </div>
 
-        <label for="time_per_frame">Select update interval:</label>
-        <select name="time_per_frame" id="time_per_frame">
-            <option value="10" {% if movie['time_per_frame'] == 10 %} selected {% endif %}>Every 10 minutes</option>
-            <option value="60" {% if movie['time_per_frame'] == 60 %} selected {% endif %}>Every hour</option>
-            <option value="1440" {% if movie['time_per_frame'] == 1440 %} selected {% endif %}>Every day</option>
-            <option value="0" {% if movie['time_per_frame'] not in [10, 60, 1440] %} selected {% endif %}>Other (provide custom time in minutes)</option>
-        </select>
 
-        <br>
-        <div id="custom_time" {% if movie['time_per_frame'] in [10, 60, 1440] %} style="display: none;" {% endif %}>
-            <label for="custom_time">Custom time (minutes):</label>
-            <input type="number" name="custom_time" id="custom_time" min="0" value="{{ movie['time_per_frame'] if movie['time_per_frame'] not in [10, 60, 1440] else 0 }}">
+            <div id="custom_time" {% if movie['time_per_frame'] in [10, 60, 1440] %} style="display: none;" {% endif %}>
+                <label for="custom_time">Custom time (minutes):</label>
+                <input type="number" name="custom_time" id="custom_time" min="0" value="{{ movie['time_per_frame'] if movie['time_per_frame'] not in [10, 60, 1440] else 0 }}">
+            </div>
+
+
+            <div id="skip_frames">
+                <label for="skip_frames">Number of frames to skip per update:</label>
+                <input type="number" name="skip_frames" id="skip_frames" min="1" value="{{ movie['skip_frames'] }}">
+            </div>
+
+            <div id="current_frame">
+                <label for="current_frame">Current active frame (this is also the starting frame for first runs):</label>
+                <input type="number" name="current_frame" id="current_frame" min="1" value="{{ movie['current_frame'] }}">
+            </div>
+
+            <div id="isRandom">
+                <label for="isRandom">You love chaos and would prefer a random frame at every interval</label>
+                <input type="checkbox" name="isRandom" id="isRandom" value="True" {% if movie['isRandom'] %} checked {% endif %}>
+            </div>
+            <div class="spacer"></div>
+            <div id="enable_quiet_hours">
+                <label>
+                    <input type="checkbox" id="use_quiet_hours" name="use_quiet_hours" value="1" {% if movie.use_quiet_hours %}checked{% endif %}>
+                    Enable Quiet Hours
+                </label>
+            </div>
+
+            <div id="quiet_hours" {% if not movie.use_quiet_hours %}style="display: none;"{% endif %}>
+                <label for="quiet_start">Quiet Hours Start (24h):</label>
+                <input type="number" name="quiet_start" id="quiet_start" min="0" max="23" value="{{ movie.quiet_start or 22 }}">
+
+                <label for="quiet_end">Quiet Hours End (24h):</label>
+                <input type="number" name="quiet_end" id="quiet_end" min="0" max="23" value="{{ movie.quiet_end or 7 }}">
+            </div>
+
+            <div class="spacer"></div>        
+            <div class="button-container">
+                <div><button id="submitButton">Submit</button></div>
+                <div><button id="refreshDisplay">Update Display Now</button></div>
+            </div>
         </div>
-
-        <br>
-        <div id="skip_frames">
-            <label for="skip_frames">Number of frames to skip per update:</label>
-            <input type="number" name="skip_frames" id="skip_frames" min="1" value="{{ movie['skip_frames'] }}">
-        </div>
-
-        <div id="current_frame">
-            <label for="current_frame">Current active frame (this is also the starting frame for first runs):</label>
-            <input type="number" name="current_frame" id="current_frame" min="1" value="{{ movie['current_frame'] }}">
-        </div>
-
-        <div id="isRandom">
-            <label for="isRandom">You love chaos and would prefer a random frame at every interval</label>
-            <input type="checkbox" name="isRandom" id="isRandom" value="True" {% if movie['isRandom'] %} checked {% endif %}>
-        </div>
-        <div class="spacer"></div>
-        <div id="enable_quiet_hours">
-            <label>
-                <input type="checkbox" id="use_quiet_hours" name="use_quiet_hours" value="1" {% if movie.use_quiet_hours %}checked{% endif %}>
-                Enable Quiet Hours
-            </label>
-        </div>
-
-        <div id="quiet_hours" {% if not movie.use_quiet_hours %}style="display: none;"{% endif %}>
-            <label for="quiet_start">Quiet Hours Start (24h):</label>
-            <input type="number" name="quiet_start" id="quiet_start" min="0" max="23" value="{{ movie.quiet_start or 22 }}">
-
-            <label for="quiet_end">Quiet Hours End (24h):</label>
-            <input type="number" name="quiet_end" id="quiet_end" min="0" max="23" value="{{ movie.quiet_end or 7 }}">
-        </div>
-
-        <div class="spacer"></div>        
-        <div class="button-container"><button id="submitButton">Submit</button><button id="refreshDisplay">Update Display Now</button></div>
     </form>
 
     <div class="spacer"></div>

--- a/templates/movies.html
+++ b/templates/movies.html
@@ -1,0 +1,40 @@
+{% extends "layout.html" %}
+
+{% block title %}Movie Frame Home{% endblock %}
+{% block content %}
+    <h1>Movie Frame Controls</h1>
+
+    {% if dev_mode %}
+        <p style="color: orange;"><strong>Developer Mode:</strong> Frame is not being sent to e-ink display.</p>
+    {% endif %}
+
+
+    {% if movies %}        
+            {% for movie in movies %}
+                <div class="movie-item">
+                    <span class="movie-link"><a href="{{ url_for('movie', movie_id=movie.id) }}">{{ movie.video_path }}</a></span>
+                    {% if movie.isActive %}
+                        <span class="active_status">Active</span>
+                    {% endif %}
+                </div>
+            {% endfor %}
+        
+    {% else %}
+        <p>No movies found. Add one from the <a href="{{ url_for('first_run') }}">first run</a> page.</p>
+    {% endif %}
+
+    <form action="{{ url_for('stop_playback') }}" method="post" style="margin-top: 1em;">
+        <button type="submit">Stop Playback</button>
+    </form>
+
+    <div>
+        <h2>System Info</h2>
+        <ul>
+            <li><strong>Total Disk:</strong> {{ disk_stats.total_gb }} GB</li>
+            <li><strong>Used Disk:</strong> {{ disk_stats.used_gb }} GB</li>
+            <li><strong>Free Disk:</strong> {{ disk_stats.free_gb }} GB</li>
+            <li><strong>Video Directory Size:</strong> {{ video_dir_size }} GB</li>
+        </ul>
+    </div>
+
+{% endblock %}

--- a/templates/movies.html
+++ b/templates/movies.html
@@ -4,18 +4,13 @@
 {% block content %}
     <h1>Movie Frame Controls</h1>
 
-    {% if dev_mode %}
-        <p style="color: orange;"><strong>Developer Mode:</strong> Frame is not being sent to e-ink display.</p>
-    {% endif %}
-
-
     {% if movies %}        
             {% for movie in movies %}
                 <div class="movie-item">
-                    <span class="movie-link"><a href="{{ url_for('movie', movie_id=movie.id) }}">{{ movie.video_path }}</a></span>
                     {% if movie.isActive %}
-                        <span class="active_status">Active</span>
+                        <div class="active_status">▶️</div>
                     {% endif %}
+                    <div class="movie-link"><a href="{{ url_for('movie', movie_id=movie.id) }}" title="{{ movie.video_path }}">{{ movie.video_path }}</a></div>                  
                 </div>
             {% endfor %}
         

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,59 @@
+{% extends "layout.html" %}
+
+{% block title %}Movie Frame Home{% endblock %}
+{% block content %}
+    <h1>Settings</h1>
+
+    <form id="settingsForm">
+        <label>
+            <input type="checkbox" name="use_quiet_hours" id="use_quiet_hours"
+                   {% if settings.use_quiet_hours %}checked{% endif %}>
+            Enable Quiet Hours
+        </label>
+        <br>
+
+        <label for="quiet_start">Quiet Start Hour (0–23):</label>
+        <input type="number" id="quiet_start" name="quiet_start" min="0" max="23"
+               value="{{ settings.quiet_start or 22 }}">
+        <br>
+
+        <label for="quiet_end">Quiet End Hour (0–23):</label>
+        <input type="number" id="quiet_end" name="quiet_end" min="0" max="23"
+               value="{{ settings.quiet_end or 7 }}">
+        <br><br>
+
+        <button type="submit">Save Settings</button>
+    </form>
+
+    <script>
+        document.getElementById('settingsForm').addEventListener('submit', function (e) {
+            e.preventDefault();
+
+            const payload = {
+                use_quiet_hours: document.getElementById('use_quiet_hours').checked ? 1 : 0,
+                quiet_start: document.getElementById('quiet_start').value,
+                quiet_end: document.getElementById('quiet_end').value
+            };
+
+            fetch('/settings', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(payload)
+            })
+            .then(res => res.json())
+            .then(data => {
+                console.log(data);
+                alert('Settings saved!');
+            })
+            .catch(err => {
+                console.error('Failed to update settings', err);
+            });
+        });
+    </script>
+    
+
+    
+
+{% endblock %}

--- a/utils/video_utils.py
+++ b/utils/video_utils.py
@@ -10,22 +10,26 @@ from datetime import datetime, timedelta
 DEV_MODE = config.read_toml_file("config.toml").get("DEVELOPMENT_MODE", False)
 
 def should_skip_due_to_quiet_hours(movie):
-    """
-    Returns True if the current time falls within the quiet hours range and quiet hours are enabled.
-    Otherwise, returns False.
-    """
-    if not movie.get('use_quiet_hours'):
-        return False  # Not enabled
+    try:
+        if not int(movie['use_quiet_hours']):
+            return False
 
-    quiet_start = int(movie.get('quiet_start', 22))
-    quiet_end = int(movie.get('quiet_end', 7))
-    current_hour = datetime.now().hour
+        quiet_start = int(movie['quiet_start'])
+        quiet_end = int(movie['quiet_end'])
+        current_hour = datetime.now().hour
 
-    if quiet_start < quiet_end:
-        return quiet_start <= current_hour < quiet_end
-    else:
-        # Overnight wraparound (e.g. 22 to 7)
-        return current_hour >= quiet_start or current_hour < quiet_end
+        print(f"[QUIET HOURS CHECK] now={current_hour}, start={quiet_start}, end={quiet_end}")
+
+        if quiet_start < quiet_end:
+            return quiet_start <= current_hour < quiet_end
+        else:
+            return current_hour >= quiet_start or current_hour < quiet_end
+    except KeyError as e:
+        print(f"[WARNING] Missing expected quiet hour field: {e}")
+        return False
+    except Exception as e:
+        print(f"[ERROR] Quiet hour check failed: {e}")
+        return False
 
 def calculate_playback_time(movie):
     total_frames = movie['total_frames']

--- a/utils/video_utils.py
+++ b/utils/video_utils.py
@@ -9,16 +9,16 @@ from datetime import datetime, timedelta
 
 DEV_MODE = config.read_toml_file("config.toml").get("DEVELOPMENT_MODE", False)
 
-def should_skip_due_to_quiet_hours(settings):
+def should_skip_due_to_quiet_hours(movie):
     """
     Returns True if the current time falls within the quiet hours range and quiet hours are enabled.
     Otherwise, returns False.
     """
-    if not settings.get('use_quiet_hours'):
+    if not movie.get('use_quiet_hours'):
         return False  # Not enabled
 
-    quiet_start = int(settings.get('quiet_start', 22))
-    quiet_end = int(settings.get('quiet_end', 7))
+    quiet_start = int(movie.get('quiet_start', 22))
+    quiet_end = int(movie.get('quiet_end', 7))
     current_hour = datetime.now().hour
 
     if quiet_start < quiet_end:
@@ -119,9 +119,9 @@ def play_video(logger):
     movie = get_active_movie()
     settings = get_settings()
 
-    # if should_skip_due_to_quiet_hours(settings):
-    #     logger.info("Playback skipped due to quiet hours.")
-    #     return
+    if should_skip_due_to_quiet_hours(movie):
+        logger.info("Playback skipped due to quiet hours.")
+        return
 
     if not movie or not settings:
         logger.warning("No active movie or settings found.")

--- a/utils/video_utils.py
+++ b/utils/video_utils.py
@@ -9,13 +9,13 @@ from datetime import datetime, timedelta
 
 DEV_MODE = config.read_toml_file("config.toml").get("DEVELOPMENT_MODE", False)
 
-def should_skip_due_to_quiet_hours(movie):
+def should_skip_due_to_quiet_hours(settings):
     try:
-        if not int(movie['use_quiet_hours']):
+        if not int(settings['use_quiet_hours']):
             return False
 
-        quiet_start = int(movie['quiet_start'])
-        quiet_end = int(movie['quiet_end'])
+        quiet_start = int(settings['quiet_start'])
+        quiet_end = int(settings['quiet_end'])
         current_hour = datetime.now().hour
 
         print(f"[QUIET HOURS CHECK] now={current_hour}, start={quiet_start}, end={quiet_end}")
@@ -123,7 +123,7 @@ def play_video(logger):
     movie = get_active_movie()
     settings = get_settings()
 
-    if should_skip_due_to_quiet_hours(movie):
+    if should_skip_due_to_quiet_hours(settings):
         logger.info("Playback skipped due to quiet hours.")
         return
 

--- a/webui.py
+++ b/webui.py
@@ -28,20 +28,27 @@ with app.app_context():
 def home():
     movies = database.get_all_movies()
     settings = database.get_settings()
+    active_movie = database.get_active_movie()
 
     disk_stats = video_utils.get_disk_usage_stats("/")
     video_dir_size = video_utils.get_directory_size_gb(settings['VideoRootPath'])
+
+    playback_time = None
+    if active_movie:
+        playback_time = video_utils.calculate_playback_time(active_movie)
 
     return render_template(
         "index.html",
         movies=movies,
         disk_stats=disk_stats,
         video_dir_size=round(video_dir_size, 2),
-        dev_mode=config_data.get("DEVELOPMENT_MODE", False)
+        dev_mode=config_data.get("DEVELOPMENT_MODE", False),
+        active_movie=active_movie,
+        playback_time=playback_time
     )
 
 @app.route('/movies')
-def home():
+def movies():
     movies = database.get_all_movies()
     settings = database.get_settings()
 

--- a/webui.py
+++ b/webui.py
@@ -4,6 +4,7 @@ from flask import Flask, render_template, request, redirect, url_for, jsonify
 from logging.handlers import RotatingFileHandler
 from utils import video_utils, eframe_inky, config
 from werkzeug.utils import secure_filename
+from datetime import datetime
 import database
 
 config_data = config.read_toml_file("config.toml")
@@ -33,6 +34,22 @@ def home():
 
     return render_template(
         "index.html",
+        movies=movies,
+        disk_stats=disk_stats,
+        video_dir_size=round(video_dir_size, 2),
+        dev_mode=config_data.get("DEVELOPMENT_MODE", False)
+    )
+
+@app.route('/movies')
+def home():
+    movies = database.get_all_movies()
+    settings = database.get_settings()
+
+    disk_stats = video_utils.get_disk_usage_stats("/")
+    video_dir_size = video_utils.get_directory_size_gb(settings['VideoRootPath'])
+
+    return render_template(
+        "movies.html",
         movies=movies,
         disk_stats=disk_stats,
         video_dir_size=round(video_dir_size, 2),

--- a/webui.py
+++ b/webui.py
@@ -85,7 +85,8 @@ def movie(movie_id):
         "movie_details.html",
         movie=movie,
         current_image_path=current_image_path,
-        playback_time=playback_time
+        playback_time=playback_time,
+        dev_mode=config_data.get("DEVELOPMENT_MODE", False),
     )
 
 @app.route('/add_movie', methods=['POST'])


### PR DESCRIPTION
### 🔕 Global Quiet Hours Support

- Moved use_quiet_hours, quiet_start, and quiet_end from per-movie scope to the global Settings table
- Updated database schema (Settings and migration logic)
- Updated should_skip_due_to_quiet_hours() to check global settings
- Created a /settings page with a form to enable/edit quiet hours

### 🖥️ Web UI Enhancements

- Added quiet hours status display on the home page, with link to settings
- Converted playback status block into a Jinja partial for reuse
- Injected quiet_info into template context (via route or globally)
- Added responsive hamburger navigation for mobile views

### 🧼 Cleanup

- Removed quiet hour fields from movie-level logic and UI
- Consolidated quiet hour logic into one reusable helper

